### PR TITLE
fixed a typo in heading NAVIGATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ https://dash-example-index.herokuapp.com/
 This Community App Gallery is designed for people new to Plotly and Dash.  It contains minimal sample apps
 with ~100 lines of code to demonstrate basic usage of graphs, components, callbacks, and layout design.
 
-### Navigtaing the Gallery:
+### Navigating the Gallery:
 1. To get started, use the search field to search for any keyword you're interested in. For example, search for "dcc.Dropdown" and you will see only
  apps containing dropdowns.
  


### PR DESCRIPTION
The word navigating was spelled incorrectly in the readme.md file so I fixed it for you in this update